### PR TITLE
* Changing default env var properties separator to '__'

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ and you'll be able to modify or add new values directly from your shell!
 
 export or add your vars before runnig your node app:
 ```bash
-MYPREFIX_a=3 MYPREFIX_b_0=4 MYPREFIX_c=5 node app.js
+MYPREFIX__a=3 MYPREFIX__b__0=4 MYPREFIX__c=5 node app.js
 ```
 
 and here's what you'll get:
@@ -154,6 +154,12 @@ config.get('b')[0]  // 4  <-- Pay attention!! It works with arrays too! :D
 config.get('c')     // 5
 ```
 
+The default properties separator is: `__` (2 underscores).
+You can use your custom separator passing it to the constructor as 3rd parameter:
+
+```javascript
+var config =  new reconfig(configValues, 'MYPREFIX', '_-_');
+```
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "JavaScript configurations as they're meant to be. Kinda.",
   "main": "reconfig.js",
   "scripts": {
-    "test": "RECONFIG_envKey=value RECONFIG_confKey=newValue RECONFIG_list_1_key=newValue mocha -b"
+    "test": "RECONFIG__envKey=value RECONFIG__confKey=newValue RECONFIG__conf_Key=newValue RECONFIG__list__1__key=newValue mocha -b"
   },
   "repository": {
     "type": "git",
@@ -26,6 +26,6 @@
   },
   "dependencies": {
     "lodash": "^2.4.1",
-    "vpo": "^1.0.0"
+    "vpo": "1.0.0"
   }
 }

--- a/reconfig.js
+++ b/reconfig.js
@@ -17,14 +17,15 @@ if (!_ || !vpo) {
  *
  * @param config
  * @param envPrefix
+ * @param separator
  * @constructor
  */
-function Reconfig(config, envPrefix) {
+function Reconfig(config, envPrefix, separator) {
   this.config = config || null;
 
   if (envPrefix) {
     if (process && process.env && typeof process.env !== String) {
-      _.merge(this.config, getConfigFromEnv(envPrefix));
+      _.merge(this.config, getConfigFromEnv(envPrefix, separator));
     } else {
       console.warn('HEY HEY HEY, this feature is supposed to be used in node only :)');
     }
@@ -55,12 +56,13 @@ function getValueByPath(object, path, fallbackValue) {
   return value;
 }
 
-function getConfigFromEnv(prefix) {
+function getConfigFromEnv(prefix, separator) {
+  separator = separator || '__';
   var envConfig = {};
 
   _.forEach(process.env, function(value, key) {
     if (contains(key, prefix)) {
-      var path = key.replace(prefix + '_', '').replace(/_/g, '.');
+      var path = key.replace(prefix + separator, '').replace(new RegExp(separator, 'g'), '.');
       vpo.set(envConfig, path, value);
     }
   });

--- a/test/reconfig.js
+++ b/test/reconfig.js
@@ -198,16 +198,19 @@ describe('Reconfig', function() {
       var values = {};
       var config = new reconfig(values, 'RECONFIG');
 
-      assert('value', config.get('envKey'));
+      assert(config.get('envKey') === 'value');
     });
 
     it('should be able to pick up stuff form the environment and override conf values', function() {
       var values = {
-        confKey: 'value'
+        confKey: 'value',
+        conf_Key: 'value'
       };
+
       var config = new reconfig(values, 'RECONFIG');
 
-      assert('newValue', config.get('confKey'));
+      assert(config.get('confKey') === 'newValue');
+      assert(config.get('conf_Key') === 'newValue');
     });
 
     it('env overriders should be able to modify arrays as well', function() {
@@ -220,7 +223,21 @@ describe('Reconfig', function() {
 
       var config = new reconfig(values, 'RECONFIG');
 
-      assert('newValue', config.get('list')[1].key);
+      assert(config.get('list')[1].key === 'newValue');
+    });
+
+    it('should be able to pick up stuff form the environment and override conf values (using custom separator)', function() {
+      process.env['RECONFIG~confKey'] = 'newValue';
+      process.env['RECONFIG~conf_Key'] = 'newValue';
+      var values = {
+        confKey: 'value',
+        conf_Key: 'value'
+      };
+
+      var config = new reconfig(values, 'RECONFIG', '~');
+
+      assert(config.get('confKey') === 'newValue');
+      assert(config.get('conf_Key') === 'newValue');
     });
 
   });


### PR DESCRIPTION
* Changing default env var properties separator to '__'
* Adding an optional 3rd parameter to reconfig consctructor: 'separator', to customize the env separator
* Locking VPO's version for some detected problem with 1.1.0 (we'll have to checko on this)