### PR TITLE
Enhancing params resolution

### DIFF
--- a/reconfig.js
+++ b/reconfig.js
@@ -95,7 +95,9 @@ Reconfig.prototype.resolveReferences = function(value) {
  */
 Reconfig.prototype.resolveParameters = function(value, parameters) {
   for (var property in parameters) {
-    value = (value) ? value.replace(':' + property, (parameters[property] || '')) : value;
+    if (value) {
+      value = value.replace(RegExp(':' + property, 'g'), (parameters[property] || ''));
+    }
   }
 
   return value;

--- a/test.js
+++ b/test.js
@@ -1,0 +1,18 @@
+var rec = require('./reconfig.js');
+var c = {
+  root: {
+    a: 'valA',
+    b: {
+      c: '{{ root.a }}',
+      d: 'valD:paramD'
+    },
+    e: 'valE:paramE',
+    f: 'valeF {{root.b.d}}'
+  }
+};
+
+var conf = new rec(c);
+
+console.log('conf: ', conf);
+console.log('conf paramD: ', conf.get('root', {paramD: 'ddddddddddd'}));
+console.log('conf app params: ', conf.get('root', {paramD: 'ddddddddddd', paramE: 'eeeeeeeeeeeeeeee'}));

--- a/test/reconfig.js
+++ b/test/reconfig.js
@@ -125,6 +125,20 @@ describe('Reconfig', function() {
       }));
     });
 
+    it('should be able to render parmas in composite values', function() {
+      var values = {
+        a: {
+          b: 'hello :what!'
+        },
+        c: '{{ a.b }}, :what'
+      };
+      var config = new reconfig(values);
+
+      assert('hello world!, world' === config.get('c', {
+        what: 'world'
+      }));
+    });
+
     it('should be able to handle self-referencing configs', function() {
       var values = {
         a: {


### PR DESCRIPTION
Now you can reference the same parameter multiple times, allowing for more elastic string composition.

Previously, if a param was referenced more than once, only the 1st occurrence was resolved:
```
/*
{ a: 'Hello :what :what' }
*/
reconfig.get('a', {what: 'world'}) // Hello world :what
```

With this patch the result will be:
```
reconfig.get('a', {what: 'world'}) // Hello world world
```
enabling for more elastic and concise config definitions yielding rather complex results in a simpler way.

would release in version: 2.1.0